### PR TITLE
Ignore all .env* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.swo
 *.swp
 /.bundle
-/.env
+/.env*
 /.foreman
 /coverage/*
 /db/*.sqlite3


### PR DESCRIPTION
This PR ignores additional `.env.*` files, such as `.env.development`.
