### PR TITLE
Allow configuration of database connection from environment variables

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,6 +6,7 @@ development: &default
   min_messages: warning
   pool: 2
   timeout: 5000
+  url: <%= ENV['DATABASE_URL'] %>
 
 test:
   <<: *default


### PR DESCRIPTION
This PR enables configuring the database connection using the `DATABASE_URL` environment variable.
