### PR TITLE
Implement a plaintext importer for guidebook dumps

### DIFF
--- a/lib/importer.rb
+++ b/lib/importer.rb
@@ -1,0 +1,35 @@
+require "organization_parser"
+
+class PlainTextImporter
+  def initialize(source)
+    @source = source
+  end
+
+  def as_json
+    @json ||= {
+      organizations: organizations
+    }
+  end
+
+  private
+
+  attr_reader :source
+
+  def organizations
+    text_grouped_by_org.map do |org|
+      OrganizationParser.new(org).as_json
+    end
+  end
+
+  def text_grouped_by_org
+    source.scan(/\w[\w\W\n]+?#{last_line}/)
+  end
+
+  def last_line
+    /^Direct Services:.+$/
+  end
+
+  def lines
+    source.split("\n")
+  end
+end

--- a/lib/organization_parser.rb
+++ b/lib/organization_parser.rb
@@ -1,0 +1,164 @@
+class OrganizationParser
+  EMAIL_REGEX = /\A\s*([^@\\s]{1,64})@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/i
+  URL_REGEX = /(?i)\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/
+
+  def initialize(organization_text)
+    @source = organization_text
+  end
+
+  def as_json
+    attributes.map { |attribute| [attribute, send(attribute)] }.to_h
+  end
+
+  private
+
+  attr_reader :source
+
+  def attributes
+    [
+      :accessibility,
+      :address,
+      :contact_name,
+      :description,
+      :eligible_population,
+      :email,
+      :faith_based,
+      :fax,
+      :fees,
+      :languages,
+      :miscellaneous,
+      :name,
+      :phone,
+      :services,
+      :url,
+      :what_to_bring,
+    ]
+  end
+
+  def accessibility
+    labeled_field(:accessibility)
+  end
+
+  def address
+    labeled_field(:address) || line_ending_in_zip_code
+  end
+
+  def line_ending_in_zip_code
+    match = source.match(/.+[^\d]\d{5}$/)
+    match && match.to_s
+  end
+
+  def contact_name
+    labeled_field(:contact_name)
+  end
+
+  def description
+    lines[1].strip.sub(URL_REGEX, "").strip
+  end
+
+  def eligible_population
+    labeled_field(:eligible_population)
+  end
+
+  def email
+    labeled_field(:email) || scan_for_email
+  end
+
+  def scan_for_email
+    match = source.match(EMAIL_REGEX)
+    match && match.to_s
+  end
+
+  def faith_based
+    labeled_field(:faith_based)
+  end
+
+  def fees
+    labeled_field(:fees)
+  end
+
+  def languages
+    parse_into_list(labeled_field(:languages))
+  end
+
+  def parse_into_list(text)
+    text.to_s.split(/(\,|\band\b|\.)/).map(&:strip) - [",", "and", "."]
+  end
+
+  def miscellaneous
+    lines[2..-1].reject do |line|
+      recognized_lines.any? { |known_line| line =~ known_line }
+    end.join("\n")
+  end
+
+  def recognized_lines
+    labeled_field_lines + ignorable_lines
+  end
+
+  def labeled_field_lines
+    field_labels.values.flatten.map { |label| /^#{label}: / }
+  end
+
+  def field_labels
+    {
+      accessibility: "Accessibility",
+      fees: "Client fees, if any",
+      contact_name: ["Contact Persons", "Contact Person"],
+      services: "Direct Services",
+      eligible_population: "Eligible Population",
+      email: "Email",
+      faith_based: "Faith Based",
+      fax: "Fax",
+      languages: "Languages Spoken",
+      address: "Location",
+      what_to_bring: "What to Bring",
+      phone: "Phone",
+    }
+  end
+
+  def ignorable_lines
+    [
+      /^Things To Know$/,
+      /^To Get Connected$/,
+    ]
+  end
+
+  def name
+    lines.first
+  end
+
+  def phone
+    labeled_field(:phone)
+  end
+
+  def fax
+    labeled_field(:fax)
+  end
+
+  def services
+    labeled_field(:services)
+  end
+
+  def url
+    source.match(URL_REGEX).to_s
+  end
+
+  def what_to_bring
+    labeled_field(:what_to_bring)
+  end
+
+  def lines
+    source.split(/\n+/).map(&:rstrip)
+  end
+
+  def labeled_field(attribute)
+    potential_labels = Array(field_labels[attribute])
+
+    matches = potential_labels.map do |label|
+      source.match(/(?<=^#{label}: ).+/)
+    end
+
+    result = matches.compact.first
+    result && result.to_s.strip
+  end
+end

--- a/spec/fixtures/getting_out_staying_out.dump.txt
+++ b/spec/fixtures/getting_out_staying_out.dump.txt
@@ -1,0 +1,169 @@
+﻿Community Housing Partnership (CHP)
+CHP is a San Francisco-based nonprofit organization.  CHP’s mission is to help homeless people secure housing and become self-sufficient.  Community Housing Partnership is an outcome focused nonprofit that fulfills its mission by developing and managing high quality supportive housing and providing services to homeless individuals, seniors and families to help them rebuild their lives and break the cycle of homelessness. www.chp-sf.org 
+
+To Get Connected
+Administration Mailing Address: 
+Occupancy & Compliance
+519 Ellis St., San Francisco, CA  94109
+Phone: (415) 563-3205 x123
+Email:  housingopportunities@chp-sf.org
+
+For information regarding properties with and without wait lists please call 415-563-3205 x123, or visit www.chp-sf.org
+
+Properties Without Waitlists:
+684 Ellis Street
+850 Broderick Street
+650 Eddy Street
+365 Fulton
+25 Essex
+3155 Scott
+374 5th St.
+810 Avenue D
+
+Notes: The above properties do not maintain waitlists.  All vacancies are filled through referrals provided to CHP by programs through the HSA and DPH depending on the property.  Please visit the website for more info.
+Things To Know
+Languages Spoken: English 
+What to Bring: State-Issued ID. Program will assist client in getting this.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: None
+Eligible Population: All currently homeless individuals and family members.  There are additional eligibility requirements per property that may include, but not limited to, annual income limits and verified disability.  Please visit the website for more onformation.
+Faith Based: No.
+
+
+Direct Services: Permanent Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Hygiene/Personal Care Items; Phone/Voicemail; Substance Abuse Treatment; Health & Wellness Education; Intensive Case Management; Outreach; Assessment & Application for Food Stamps, General Assistance, and SSI; Employment Training; Job Readiness/Life Skills; Parenting Support/Education; Services for Children. Referral to other services as needed.
+Catholic Charities/CYO   Leland House
+Cathonic Charities/CYO’s mission is to house homeless people with disabling HIV and AIDS. At Leland House, which provides permanent housing, we respond to residents on a Harm Reduction basis working with behaviors as they become difficult for others and when they  impede the safety of the resident themselves.  www.cccyo.org
+
+To Get Connected
+Contact Persons:  Timothy Quinn, Intake Coordinator
+Phone: (415) 405-2063 
+Fax: (415) 337-1137
+Email: TQuinn@cccyo.org 
+Intake Days: Wednesdays and Thursdays
+Facility Hours: 24 hours/7 days
+Location: 141 Leland Avenue, San Francisco, CA  94134 
+Notes: Referral required. Intake appointment needed – no drop-ins.
+Things To Know
+Languages Spoken: English, Spanish and German.
+What to Bring: State-Issued ID, Social Security Card, Proof of SF Residency, TB Clearance; Medi-Cal card or other proof of insurance so that medications can be ordered.
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Client fees, if any: Rent is calculated at 30% of monthly income. There is an annual income limit.
+Eligible Population: All currently homeless individuals, 18 years or older, with disabling HIV or AIDS, psychiatric disorders or substance abuse issues.
+Faith Based: No.
+
+Direct Services: Permanent Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Food/Prepared Meals; P.O. Box/Mail Service; Voicemail; Shower Facilities; Utilities (hot water, heat); Co-occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education through in house dietician; Anger Management; Group Counseling/Therapy - Anger Management, HIV Support, Harm Reduction; Money Management/Personal Financial Education; Many additional supportive services available upon referral behavioral health, employment, case management, and other specialists, as needed.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Compass Family Services   SF Home  
+Compass SF HOME helps families in danger of homelessness to stabilize and maintain their housing and rapidly re-houses homeless families so that they can work towards long-term economic self-sufficiency.  The program is designed to help homeless families find a unit, and then provide a rental subsidy paired with case management until the family increases their income to the point that they can pay the rent on their own.    www.compass-sf.org
+
+To Get Connected
+Contact Person: Beth Mitchell, Program Director
+Phone: (415) 644-0504 ext. 2201
+Email: bmitchell@compass-sf.org 
+Location: 995 Market St, 5th Floor, SF 94103
+Notes: Please call for more information and to receive an application packet.  No referral required but families we prioritize families who are either in a shelter or on the Connecting Point family shelter waitlist. 
+
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: We will let you know what documents are needed at the time you apply.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: None, although families must pay 40-50% of their net income towards the rent in their unit.
+Eligible Population: Homeless families staying in San Francisco. Must have more than 50% custody of a child under 18, minimum income of $500, maximum income 50% AMI. Must have a concrete plan to increase your income to the point where you can afford rent.
+Faith Based: No.
+
+Direct Services: Assistance Obtaining Permanent Housing; Rental Subsidies; Intensive Case Management; Education and Professional Goals; Money management; Access to a Food Pantry; Clothing; Personal Hygiene Products; Diapers and Baby Supplies; Transportation Assistance; Access to Educational/Recreational Activities for Children. 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hamilton Family Center   The Dudley Apartments
+Our mission is to break the cycle of homelessness and poverty.  Through a housing-first approach, we provide a continuum of housing solutions and hands-on services that promote self-sufficiency for families and individuals, and foster the potential of children and youth.  The Dudley Apartments is a 75-unit Permanent Supportive Housing development where Hamilton family Center offers intensive case management services for single adults, seniors, families, and children managing disabilities who have experienced homelessness.  www.hamiltonfamilycenter.org
+To Get Connected
+Contact Person: Mary Brown, Case Manager
+Phone: (415) 861-8645 x105
+Fax:  (415) 861-86447
+Email: mbrown@hamiltonfamilycenter.org 
+Location: 172 6th Street, San Francisco, CA  94103
+Notes: Please call for an appointment.  Referal from a service provider who can supply a certificate of homelessness is required.  A waitlist is managed through Mercy Housing.  
+See listing under Hamilton First Avenue program for other housing options and instructions.
+
+
+Things To Know
+Languages Spoken: English, Spanish. 
+What to Bring: State issued ID, Social Security Card.  Program will assist clients getting these documents.
+Accessibility: Wheelchair accessible. 
+Client fees, if any: Client pays 30% of their income toward rent.
+Eligible Population: Men, women, transgender, pregnant women, women with children, families.  There are extensive restrictions for this program as it works with Mercy Housing providing section 8 units.  Please contact the Dudley Apartments staff for more information.
+Faith Based: No.
+
+Direct Services: Permanent Housing; Access to Internet; Assistance Getting Driver’s License/Other ID; Food/Prepared Meals; P.O. Box/Mail Service; Shower Facilities; Mental Health Treatment; Health & Wellness Eductaion; Intensive Case Management; Individual Counseling/Therapy; Housing Placement Assistance; Assistance Applying for CalFresh/Food Stamps; Assistance Applying for PAES/GA/CalWorks; Assessment & Application for SSI; Credit Repair; Job Readiness/Life Skills; Money Management/Personal Financial Eduction; Assistance Applying for Health Insurance; Couples/Family Counseling; Family Reunification; Parenting Support/Education; Services for Children.
+
+
+San Francisco Human Services Agency   San Francisco Rental Assistance Program
+Provide back rent or security deposit to low income San Francisco residents meeting criteria. www.sfhsa.org
+
+To Get Connected
+Contact Person: Darlene Fernandez-Ash, Rental Assistance Coordinator
+Phone: (415) 557-6484  
+Fax: (415) 557-6033 
+Hours: Monday – Friday, 9:00am to 5:00pm
+Mailing Address: P.O. Box 7988, San Francisco, CA 94120, worker #ZB34
+Notes: After verifying need and eligibility based on phone or mail inquiry, clients are referred to a community agency that can help them complete a rental assistance application. No drop-ins.
+Things To Know
+What to Bring: State-Issued ID; Social Security Card; Birth Certificates (for children); Proof of Income; Lease Agreement; and other supporting documentation, as needed.
+Client fees, if any: None.
+Primary Community Served: Low-income (80% AMI or below) families with minor children in their custody; adults (verifiably disabled, senior 55+), emancipated foster youth, veterans, victim of recent violence. Must be San Francisco resident.
+Faith Based: No.
+
+Direct Services: Assistance with back rent; security deposit; critical family needs. Referrals to other services as needed.
+Tenderloin Housing Clinic   New Roads Program
+In partnership with San Francisco Adult Probation, the New Roads Program provides services to clients who are on Adult Probation in San Franisco.  The New Roads Program is a rental subsidy program designed for clients who are homeless or unstably housed, and are seeking housing and financial stability.  Services for clients accepted into the program include:  housing search assistance; rental subsidies; financial assistance; and supportive setvices.  The goal for all New Roads clients is to obtain permanent housing and increase monthly income during program participation, in order to become self-sufficient. www.thclinic.org
+
+To Get Connected
+Contact Person: Naomi Prochovnick
+Phone: (415) 771-2427 x125  
+Fax: (415) 921-8691 
+Hours: Monday – Friday, 9:30am to 4:00pm
+Location: 427 Turk Street, San Francisco, CA 94102
+Notes: Clients may phone or drop-in to inquire about services, but will need an appointment for an intake.  Clients must be on supervised Adult Probation in San Francisco and must be referred by their Deputy Probation Officer.
+Things To Know
+Languages Spoken:  English, Spanish, Cantonese, Mandarin, Assamese. 
+Accessibility: Wheelchair accessible. Other disabilities are accommodated.
+Eligible Population: Clients must be referred  to the program by the San Francisco Adult Probation Department, must be currently homeless or unstably housed, and have at least 12 months remaining on supervision.
+Faith Based: No.
+
+
+
+Direct Services: Housing Placement Assistance; Rental Subsidies; Supportive Services; Financial and Clothing Assistance.

--- a/spec/fixtures/getting_out_staying_out.expected.json
+++ b/spec/fixtures/getting_out_staying_out.expected.json
@@ -1,0 +1,123 @@
+{
+  "organizations": [
+    {
+      "name": "Community Housing Partnership (CHP)",
+      "description": "CHP is a San Francisco-based nonprofit organization.  CHP’s mission is to help homeless people secure housing and become self-sufficient.  Community Housing Partnership is an outcome focused nonprofit that fulfills its mission by developing and managing high quality supportive housing and providing services to homeless individuals, seniors and families to help them rebuild their lives and break the cycle of homelessness.",
+      "url": "www.chp-sf.org",
+      "address": "519 Ellis St., San Francisco, CA  94109",
+      "phone": "(415) 563-3205 x123",
+      "fax": null,
+      "email":  "housingopportunities@chp-sf.org",
+
+      "miscellaneous": "Administration Mailing Address:\nOccupancy & Compliance\n519 Ellis St., San Francisco, CA  94109\nFor information regarding properties with and without wait lists please call 415-563-3205 x123, or visit www.chp-sf.org\nProperties Without Waitlists:\n684 Ellis Street\n850 Broderick Street\n650 Eddy Street\n365 Fulton\n25 Essex\n3155 Scott\n374 5th St.\n810 Avenue D\nNotes: The above properties do not maintain waitlists.  All vacancies are filled through referrals provided to CHP by programs through the HSA and DPH depending on the property.  Please visit the website for more info.",
+      "languages": ["English"],
+      "what_to_bring": "State-Issued ID. Program will assist client in getting this.",
+      "accessibility": "Wheelchair accessible. Other disabilities are accommodated.",
+      "fees": "None",
+      "eligible_population": "All currently homeless individuals and family members.  There are additional eligibility requirements per property that may include, but not limited to, annual income limits and verified disability.  Please visit the website for more onformation.",
+      "faith_based": "No.",
+
+      "services": "Permanent Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Hygiene/Personal Care Items; Phone/Voicemail; Substance Abuse Treatment; Health & Wellness Education; Intensive Case Management; Outreach; Assessment & Application for Food Stamps, General Assistance, and SSI; Employment Training; Job Readiness/Life Skills; Parenting Support/Education; Services for Children. Referral to other services as needed."
+    },
+    {
+      "name": "Catholic Charities/CYO   Leland House",
+      "description": "Cathonic Charities/CYO’s mission is to house homeless people with disabling HIV and AIDS. At Leland House, which provides permanent housing, we respond to residents on a Harm Reduction basis working with behaviors as they become difficult for others and when they  impede the safety of the resident themselves.",
+      "url": "www.cccyo.org",
+      "address": "141 Leland Avenue, San Francisco, CA  94134",
+      "contact_name": "Timothy Quinn, Intake Coordinator",
+      "phone": "(415) 405-2063",
+      "fax": "(415) 337-1137",
+      "email": "TQuinn@cccyo.org",
+
+      "miscellaneous": "Intake Days: Wednesdays and Thursdays\nFacility Hours: 24 hours/7 days\nNotes: Referral required. Intake appointment needed – no drop-ins.",
+      "languages": ["English", "Spanish", "German"],
+      "what_to_bring": "State-Issued ID, Social Security Card, Proof of SF Residency, TB Clearance; Medi-Cal card or other proof of insurance so that medications can be ordered.",
+      "accessibility": "Wheelchair accessible. Other disabilities are accommodated.",
+      "fees": "Rent is calculated at 30% of monthly income. There is an annual income limit.",
+      "eligible_population": "All currently homeless individuals, 18 years or older, with disabling HIV or AIDS, psychiatric disorders or substance abuse issues.",
+      "faith_based": "No.",
+
+      "services": "Permanent Housing; Access to Internet; Assistance Getting Drivers License or Other ID; Food/Prepared Meals; P.O. Box/Mail Service; Voicemail; Shower Facilities; Utilities (hot water, heat); Co-occurring Disorder/Dual Diagnosis Treatment; Health & Wellness Education through in house dietician; Anger Management; Group Counseling/Therapy - Anger Management, HIV Support, Harm Reduction; Money Management/Personal Financial Education; Many additional supportive services available upon referral behavioral health, employment, case management, and other specialists, as needed."
+    },
+    {
+      "name": "Compass Family Services   SF Home",
+      "description": "Compass SF HOME helps families in danger of homelessness to stabilize and maintain their housing and rapidly re-houses homeless families so that they can work towards long-term economic self-sufficiency.  The program is designed to help homeless families find a unit, and then provide a rental subsidy paired with case management until the family increases their income to the point that they can pay the rent on their own.",
+      "url": "www.compass-sf.org",
+      "address": "995 Market St, 5th Floor, SF 94103",
+      "contact_name": "Beth Mitchell, Program Director",
+      "phone": "(415) 644-0504 ext. 2201",
+      "email": "bmitchell@compass-sf.org",
+
+      "miscellaneous": "Notes: Please call for more information and to receive an application packet.  No referral required but families we prioritize families who are either in a shelter or on the Connecting Point family shelter waitlist.",
+      "languages": ["English", "Spanish"],
+      "what_to_bring": "We will let you know what documents are needed at the time you apply.",
+      "accessibility": "Wheelchair accessible.",
+      "fees": "None, although families must pay 40-50% of their net income towards the rent in their unit.",
+      "eligible_population": "Homeless families staying in San Francisco. Must have more than 50% custody of a child under 18, minimum income of $500, maximum income 50% AMI. Must have a concrete plan to increase your income to the point where you can afford rent.",
+      "faith_based": "No.",
+
+      "services": "Assistance Obtaining Permanent Housing; Rental Subsidies; Intensive Case Management; Education and Professional Goals; Money management; Access to a Food Pantry; Clothing; Personal Hygiene Products; Diapers and Baby Supplies; Transportation Assistance; Access to Educational/Recreational Activities for Children."
+    },
+    {
+      "name": "Hamilton Family Center   The Dudley Apartments",
+      "description": "Our mission is to break the cycle of homelessness and poverty.  Through a housing-first approach, we provide a continuum of housing solutions and hands-on services that promote self-sufficiency for families and individuals, and foster the potential of children and youth.  The Dudley Apartments is a 75-unit Permanent Supportive Housing development where Hamilton family Center offers intensive case management services for single adults, seniors, families, and children managing disabilities who have experienced homelessness.",
+      "url": "www.hamiltonfamilycenter.org",
+      "address": "172 6th Street, San Francisco, CA  94103",
+      "contact_name": "Mary Brown, Case Manager",
+      "phone": "(415) 861-8645 x105",
+      "fax": "(415) 861-86447",
+      "email": "mbrown@hamiltonfamilycenter.org",
+
+      "miscellaneous": "Notes: Please call for an appointment.  Referal from a service provider who can supply a certificate of homelessness is required.  A waitlist is managed through Mercy Housing.\nSee listing under Hamilton First Avenue program for other housing options and instructions.",
+      "languages": ["English", "Spanish"],
+      "what_to_bring": "State issued ID, Social Security Card.  Program will assist clients getting these documents.",
+      "accessibility": "Wheelchair accessible.",
+      "fees": "Client pays 30% of their income toward rent.",
+      "eligible_population": "Men, women, transgender, pregnant women, women with children, families.  There are extensive restrictions for this program as it works with Mercy Housing providing section 8 units.  Please contact the Dudley Apartments staff for more information.",
+      "faith_based": "No.",
+
+      "services": "Permanent Housing; Access to Internet; Assistance Getting Driver’s License/Other ID; Food/Prepared Meals; P.O. Box/Mail Service; Shower Facilities; Mental Health Treatment; Health & Wellness Eductaion; Intensive Case Management; Individual Counseling/Therapy; Housing Placement Assistance; Assistance Applying for CalFresh/Food Stamps; Assistance Applying for PAES/GA/CalWorks; Assessment & Application for SSI; Credit Repair; Job Readiness/Life Skills; Money Management/Personal Financial Eduction; Assistance Applying for Health Insurance; Couples/Family Counseling; Family Reunification; Parenting Support/Education; Services for Children."
+    },
+    {
+      "name": "San Francisco Human Services Agency   San Francisco Rental Assistance Program",
+      "description": "Provide back rent or security deposit to low income San Francisco residents meeting criteria.",
+      "url": "www.sfhsa.org",
+      "address": null,
+      "contact_name": "Darlene Fernandez-Ash, Rental Assistance Coordinator",
+      "phone": "(415) 557-6484",
+      "fax": "(415) 557-6033",
+      "email": null,
+
+      "miscellaneous": "Hours: Monday – Friday, 9:00am to 5:00pm\nMailing Address: P.O. Box 7988, San Francisco, CA 94120, worker #ZB34\nNotes: After verifying need and eligibility based on phone or mail inquiry, clients are referred to a community agency that can help them complete a rental assistance application. No drop-ins.\nPrimary Community Served: Low-income (80% AMI or below) families with minor children in their custody; adults (verifiably disabled, senior 55+), emancipated foster youth, veterans, victim of recent violence. Must be San Francisco resident.",
+      "languages": [],
+      "what_to_bring": "State-Issued ID; Social Security Card; Birth Certificates (for children); Proof of Income; Lease Agreement; and other supporting documentation, as needed.",
+
+      "accessibility": null,
+      "fees": "None.",
+      "eligible_population": null,
+      "faith_based": "No.",
+
+      "services": "Assistance with back rent; security deposit; critical family needs. Referrals to other services as needed."
+    },
+    {
+      "name": "Tenderloin Housing Clinic   New Roads Program",
+      "description": "In partnership with San Francisco Adult Probation, the New Roads Program provides services to clients who are on Adult Probation in San Franisco.  The New Roads Program is a rental subsidy program designed for clients who are homeless or unstably housed, and are seeking housing and financial stability.  Services for clients accepted into the program include:  housing search assistance; rental subsidies; financial assistance; and supportive setvices.  The goal for all New Roads clients is to obtain permanent housing and increase monthly income during program participation, in order to become self-sufficient.",
+      "url": "www.thclinic.org",
+      "address": "427 Turk Street, San Francisco, CA 94102",
+      "contact_name": "Naomi Prochovnick",
+      "phone": "(415) 771-2427 x125",
+      "fax": "(415) 921-8691",
+      "email": null,
+
+      "miscellaneous": "Hours: Monday – Friday, 9:30am to 4:00pm\nNotes: Clients may phone or drop-in to inquire about services, but will need an appointment for an intake.  Clients must be on supervised Adult Probation in San Francisco and must be referred by their Deputy Probation Officer.",
+      "languages": ["English", "Spanish", "Cantonese", "Mandarin", "Assamese"],
+      "what_to_bring": null,
+      "accessibility": "Wheelchair accessible. Other disabilities are accommodated.",
+      "fees": null,
+      "eligible_population": "Clients must be referred  to the program by the San Francisco Adult Probation Department, must be currently homeless or unstably housed, and have at least 12 months remaining on supervision.",
+      "faith_based": "No.",
+
+      "services": "Housing Placement Assistance; Rental Subsidies; Supportive Services; Financial and Clothing Assistance."
+    }
+  ]
+}

--- a/spec/lib/importer_spec.rb
+++ b/spec/lib/importer_spec.rb
@@ -1,0 +1,36 @@
+require "importer"
+require "json"
+
+describe PlainTextImporter do
+  describe "#as_json" do
+    it "converts to a JSON-compatible object" do
+      importer = PlainTextImporter.new(plain_text_dump)
+
+      output = importer.as_json
+
+      expected_json_object[:organizations].each_with_index do |expected, index|
+        org = output[:organizations][index]
+
+        expected.each do |key, expected_value|
+          expect(org[key]).to eq(expected_value)
+        end
+      end
+    end
+  end
+end
+
+def expected_json_object
+  JSON.parse(File.read(expected_json_file), symbolize_names: true)
+end
+
+def plain_text_dump
+  File.read(plaintext_dump_file)
+end
+
+def plaintext_dump_file
+  "spec/fixtures/getting_out_staying_out.dump.txt"
+end
+
+def expected_json_file
+  "spec/fixtures/getting_out_staying_out.expected.json"
+end


### PR DESCRIPTION
- Add first six organizations from the plaintext dump of the guidebook
- Hand-create the expected JSON output from importing the file
- Create an importer to transform from guidebook text to JSON

https://trello.com/c/3xB4TrDd
