### PR TITLE
Add sample login credentials to login screen

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1,2 +1,3 @@
 @import "components/organizations";
 @import "components/forms";
+@import "components/credentials";

--- a/app/assets/stylesheets/components/_credentials.scss
+++ b/app/assets/stylesheets/components/_credentials.scss
@@ -1,0 +1,12 @@
+.credentials {
+  @include clearfix;
+  @include fill-parent;
+  display: flex;
+  flex-direction: column;
+
+  &__hint {
+    @include span-columns(6);
+    @include shift(3);
+    margin-bottom: $gutter;
+  }
+}

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,14 @@
 <h2>Log in</h2>
 
+<div class="credentials">
+  <div class="credentials__hint">
+    SF OpenReferral is still in development, and we're working with sample data.
+    If you would like to click around, feel free to log in with:
+  </div>
+  <div class="credentials__hint">Username: <code>steve@example.com</code></div>
+  <div class="credentials__hint">Password: <code>badpassword</code></div>
+</div>
+
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-inputs">
     <%= f.input :email, required: false, autofocus: true %>


### PR DESCRIPTION
Why?

Many people had trouble finding/remembering the correct login credentials to access the production app.

By displaying the credentials directly above the sign in form, we'll save people a lot of time and confusion.
