### PR TITLE
Use consistent org names in percy specs

### DIFF
--- a/spec/features/admin_views_organization_spec.rb
+++ b/spec/features/admin_views_organization_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "Admin views organization" do
   scenario "admin does not see organization details initially", :js do
     admin = create(:admin)
-    create(:organization)
+    create(:organization, name: "Org")
     login_as(admin, scope: :admin)
 
     visit organizations_path
@@ -14,7 +14,7 @@ feature "Admin views organization" do
 
   scenario "admin opens organization in a modal", :js do
     admin = create(:admin)
-    organization = create(:organization)
+    organization = create(:organization, name: "Org")
     login_as(admin, scope: :admin)
 
     visit organizations_path


### PR DESCRIPTION
Percy was reporting changing elements on the page when different
organization names were used in the test.

Because we use random test ordering and a factory girl sequence
to generate org names, the organizations usually were named differently
between test runs, and created a visual diff in Percy.
