### PR TITLE
Add miscellaneous field to organizations

### DIFF
--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -5,6 +5,7 @@
     <%= f.input :name %>
     <%= f.input :url %>
     <%= f.input :description %>
+    <%= f.input :miscellaneous %>
     <%= f.input :address %>
     <%= f.input :phones, as: :array %>
     <%= f.input :emails, as: :array %>

--- a/db/migrate/20151025174121_add_miscellaneous_to_organizations.rb
+++ b/db/migrate/20151025174121_add_miscellaneous_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddMiscellaneousToOrganizations < ActiveRecord::Migration
+  def change
+    add_column :organizations, :miscellaneous, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151025120242) do
+ActiveRecord::Schema.define(version: 20151025174121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20151025120242) do
     t.string   "demographics"
     t.string   "fees"
     t.string   "accessibility"
+    t.text     "miscellaneous"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,7 +16,7 @@ data[:organizations].each do |org|
     phones: [org[:phone]],
     # org[:fax: null,
     emails: [org[:email]],
-    # org[:miscellaneous],
+    miscellaneous: org[:miscellaneous],
     languages: org[:languages],
     # org[:what_to_bring],
     accessibility: org[:accessibility],


### PR DESCRIPTION
Problem:

When information about an organization is not parsed correctly,
the info that could not be detected is returned by the import script as
a catch-all 'miscellaneous' field. Since there was no corresponding
field in the database, the information that could not be parsed was
lost.

Solution:

Add a miscellaneous field to store the information that could not be
captured.

Next steps:

Go through organizations that have data in the miscellaneous field to
further improve the import script
